### PR TITLE
Update version badge link to point to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2021-08-24
+
+### Added
+
+- Version badge in README links to this changelog
+
 ## [0.3.1] - 2021-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSPO Project Template
 
-[![OSS Template Version](https://img.shields.io/badge/OSS%20Template-0.3.1-7f187f.svg)](https://github.com/wayfair-incubator/oss-template/blob/main/CHANGELOG.md)
+[![OSS Template Version](https://img.shields.io/badge/OSS%20Template-0.3.2-7f187f.svg)](https://github.com/wayfair-incubator/oss-template/blob/main/CHANGELOG.md)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 ## Before You Start...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSPO Project Template
 
-[![OSS Template Version](https://img.shields.io/badge/OSS%20Template-0.3.1-7f187f.svg)](https://github.com/wayfair-incubator/oss-template/)
+[![OSS Template Version](https://img.shields.io/badge/OSS%20Template-0.3.1-7f187f.svg)](https://github.com/wayfair-incubator/oss-template/blob/main/CHANGELOG.md)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 ## Before You Start...


### PR DESCRIPTION
## Description

Create a link from the version badge to the changelog to allow users to easily see what changes have been implemented in the template since using it as a basis for their repository. Any update process will still be manual, but this provides some value to users at negligible cost.

Change implemented based on [comment by draco2003](https://github.com/wayfair-incubator/oss-template/pull/9#discussion_r683607043).

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/oss-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
