### PR TITLE
Update lint workflow trigger behavior

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: lint
 
-on: ["push", "pull_request"]
+on: # Rebuild any PRs and main branch changes
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on: # Rebuild any PRs and main branch changes
   push:
     branches:
       - main
+      - develop
   pull_request:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.7] - 2022-04-04
+
+- Update lint workflow trigger behavior
+
 ## [0.3.6] - 2022-03-22
 
 - Bumps actions/checkout from 2 to 3


### PR DESCRIPTION
## Description

Fixes linter workflow to _only_ trigger on pull request events + pushes to the `main` or `develop` branches, thus avoiding duplicate CI runs when pushing commits to a PR branch.

### Previous Behavior

<img width="520" alt="Screen Shot 2022-04-04 at 5 11 27 PM" src="https://user-images.githubusercontent.com/2418071/161632993-b492d393-eb2c-4bf9-bf76-971d68418141.png">

### New Behavior

<img width="537" alt="Screen Shot 2022-04-04 at 5 11 09 PM" src="https://user-images.githubusercontent.com/2418071/161633001-75362dfe-faf0-4307-8a34-eeb1fd07a3e5.png">

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)