### PR TITLE
Use hosted presets in base Renovate config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### TBA
 
+## [0.3.9] - 2022-11-08
+
+### Changed
+
+- Leveraging [hosted presets](https://docs.renovatebot.com/config-presets/) for `renovate.json` config
+
 ## [0.3.8] - 2022-08-15
 
 ### Added
@@ -112,7 +118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README template
 - Security guidance
 
-[unreleased]: https://github.com/wayfair-incubator/oss-template/compare/v0.3.8...HEAD
+[unreleased]: https://github.com/wayfair-incubator/oss-template/compare/v0.3.9...HEAD
+[0.3.9]: https://github.com/wayfair-incubator/oss-template/compare/v0.3.8...v0.3.9
 [0.3.8]: https://github.com/wayfair-incubator/oss-template/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/wayfair-incubator/oss-template/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/wayfair-incubator/oss-template/compare/v0.3.5...v0.3.6

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ In trying to keep this template as generic and reusable as possible, there are s
 - [ ] Add names and contact information for actual project maintainers to [`MAINTAINERS.md`](MAINTAINERS.md).
 - [ ] Delete the content of [`CHANGELOG.md`](CHANGELOG.md). We encourage you to [keep a changelog](https://keepachangelog.com/en/1.0.0/).
 - [ ] Configure [`renovate.json`](renovate.json) for your project's language and tooling dependencies.
+  - [ ] Note that the base `renovate.json` file included with this template inherits most of its configuration logic from Wayfair OSPO's recommended presets, hosted [here](https://github.com/wayfair/ospo-automation/blob/main/default.json). If your project does not require advanced dependency configuration, this may be sufficient for your needs.
   - [ ] 💡 To learn more about using and configuring [Renovate](http://renovatebot.com/), check out our [wayfair.github.io](https://wayfair.github.io) article: **[Managing Project Dependencies](https://wayfair.github.io/docs/managing-dependencies/)**.
 - [ ] Replace the generic content in this file with the relevant details about your project.
 - [ ] Acknowledge that some features like [branch protection rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule) are only available when the repo is `public`.
@@ -82,7 +83,7 @@ Contributions are what make the open source community such an amazing place to l
 
 ## License
 
-Distributed under the `<License name>` License. See `LICENSE` for more information.
+Distributed under the `<License name>` License. See [LICENSE](LICENSE) for more information.
 
 ## Contact
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,29 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Renovate configuration recommended by the Wayfair OSPO",
-  "labels": [
-    "renovate/{{depName}}"
-  ],
+  "description": "Wayfair OSPO recommended presets (https://github.com/wayfair/ospo-automation/blob/main/default.json)",
   "extends": [
-    "config:base",
-    ":dependencyDashboard",
-    ":rebaseStalePrs"
-  ],
-  "schedule": [
-    "before 3am every weekday"
-  ],
-  "enabledManagers": [
-    "github-actions"
-  ],
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "groupName": "Minor Updates",
-      "automerge": true
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
-    }
+    "github>wayfair/ospo-automation"
   ]
 }


### PR DESCRIPTION
## Description

We'd like to shift towards a model where the `ospo-automation` repository serves as the source of truth for storing our recommended base Renovate configuration for all of Wayfair's open source projects, including the `oss-template`. The template's base `renovate.json` config will now inherit the majority of its logic from a [default.json](https://github.com/wayfair/ospo-automation/blob/main/default.json) file hosted on `ospo-automation`.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)